### PR TITLE
to make build version for the live server

### DIFF
--- a/react-app/package.json
+++ b/react-app/package.json
@@ -2,6 +2,7 @@
   "name": "react-app",
   "version": "0.1.0",
   "private": true,
+  "homepage": "http://myvmlab.senecacollege.ca:6471/mindSpark_App/react-app/build/",
   "dependencies": {
     "react": "^16.8.6",
     "react-dom": "^16.8.6",


### PR DESCRIPTION
I added a code to make build version for the live server.
Now mindSpark-react-app is live on 'http://myvmlab.senecacollege.ca:6471/mindSpark_App/react-app/build/'